### PR TITLE
Replace use of runCommand with the driver's CRUD methods

### DIFF
--- a/chameleon/src/main/java/org/hibernate/omm/ast/MongoSelectQueryAstTranslator.java
+++ b/chameleon/src/main/java/org/hibernate/omm/ast/MongoSelectQueryAstTranslator.java
@@ -152,7 +152,7 @@ public class MongoSelectQueryAstTranslator extends AbstractMongoQuerySqlTranslat
             //if ( queryPartForRowNumbering == null ) {
             //visitForUpdateClause( querySpec );
             //}
-            appendSql(" } ], cursor: {} }");
+            appendSql(" } ] }");
         } finally {
             this.queryPartStack.pop();
             this.queryPartForRowNumbering = queryPartForRowNumbering;

--- a/chameleon/src/main/java/org/hibernate/omm/jdbc/MongoConnection.java
+++ b/chameleon/src/main/java/org/hibernate/omm/jdbc/MongoConnection.java
@@ -31,7 +31,6 @@ public class MongoConnection implements ConnectionAdapter {
     private final MongoDatabase mongoDatabase;
 
     private boolean autoCommit;
-    private boolean supportsTransaction;
     private boolean closed;
 
     @Nullable
@@ -62,9 +61,6 @@ public class MongoConnection implements ConnectionAdapter {
         String version = result.getString("version");
         List<Integer> versionArray = result.getList("versionArray", Integer.class);
 
-        if (versionArray.get(0) >= 4) {
-            supportsTransaction = true;
-        }
         return new DatabaseMetaDataAdapter() {
 
             @Override
@@ -107,7 +103,7 @@ public class MongoConnection implements ConnectionAdapter {
 
     @Override
     public void setAutoCommit(boolean autoCommit) {
-        if (!autoCommit && supportsTransaction) {
+        if (!autoCommit) {
             this.clientSession.startTransaction();
         }
         this.autoCommit = autoCommit;
@@ -115,14 +111,14 @@ public class MongoConnection implements ConnectionAdapter {
 
     @Override
     public void commit() {
-        if (!autoCommit && supportsTransaction) {
+        if (!autoCommit) {
             clientSession.commitTransaction();
         }
     }
 
     @Override
     public void rollback() {
-        if (!autoCommit && supportsTransaction) {
+        if (!autoCommit) {
             clientSession.abortTransaction();
         }
     }

--- a/chameleon/src/test/java/org/hibernate/omm/query/NativeQueryTests.java
+++ b/chameleon/src/test/java/org/hibernate/omm/query/NativeQueryTests.java
@@ -28,7 +28,10 @@ class NativeQueryTests extends AbstractMongodbIntegrationTests {
             return book;
         });
 
-        var nativeQuery = "{ find: \"books\", filter: { _id: { $eq: ? } }, projection: { _id: 1, author: 1, publishYear: 1, title: 1 } }";
+        var nativeQuery = "{ aggregate: \"books\", pipeline: [" +
+                "{ $match :  { _id: { $eq: ? } } }, " +
+                "{ $project: { _id: 1, publishYear: 1, title: 1, author: 1 } }" +
+                "] }";
         getSessionFactory().inTransaction(session -> {
             var query = session.createNativeQuery(nativeQuery, Book.class);
             query.setParameter(1, id);


### PR DESCRIPTION
This wlll ensure that:

1. Reads and writes are automatically retried by the driver
2. Reads and writes will properly participate in transactions
3. Cursors will be properly iterated and closed