### PR TITLE
Customize parameter marker so that it creates valid JSON

### DIFF
--- a/chameleon-core/src/main/java/org/hibernate/omm/dialect/MongoDialect.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/dialect/MongoDialect.java
@@ -28,7 +28,9 @@ import org.hibernate.omm.type.ObjectIdJdbcType;
 import org.hibernate.omm.util.StringUtil;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
+import org.hibernate.sql.ast.spi.ParameterMarkerStrategy;
 import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.spi.TypeConfiguration;
 
 import static org.hibernate.type.SqlTypes.ARRAY;
@@ -96,4 +98,20 @@ public class MongoDialect extends Dialect {
         functionRegistry.register("array_includes", new MongoArrayIncludesFunction(typeConfiguration));
     }
 
+    @Override
+    public ParameterMarkerStrategy getNativeParameterMarkerStrategy() {
+        return MongoParameterMarkerStrategy.INSTANCE;
+    }
+
+    private static class MongoParameterMarkerStrategy implements ParameterMarkerStrategy {
+        /**
+         * Singleton access
+         */
+        public static final MongoParameterMarkerStrategy INSTANCE = new MongoParameterMarkerStrategy();
+
+        @Override
+        public String createMarker(int position, JdbcType jdbcType) {
+            return "{$undefined: true}";
+        }
+    }
 }

--- a/chameleon-core/src/main/java/org/hibernate/omm/jdbc/MongoStatement.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/jdbc/MongoStatement.java
@@ -67,6 +67,7 @@ public class MongoStatement implements StatementAdapter {
         throwExceptionIfClosed();
 
         var command = BsonDocument.parse(sql);
+        replaceParameterMarkers(command);
         var collection = mongoDatabase.getCollection(command.getString("aggregate").getValue(),
                 BsonDocument.class);
         var pipeline = command.getArray("pipeline").stream().map(BsonValue::asDocument).toList();
@@ -103,6 +104,8 @@ public class MongoStatement implements StatementAdapter {
         throwExceptionIfClosed();
         BsonDocument command = BsonDocument.parse(sql);
 
+        replaceParameterMarkers(command);
+
         String commandName = command.getFirstKey();
         MongoCollection<BsonDocument> collection = mongoDatabase.getCollection(command.getString(commandName).getValue(),
                 BsonDocument.class);
@@ -134,6 +137,9 @@ public class MongoStatement implements StatementAdapter {
             default:
                 throw new NotSupportedSQLException("unknown command: " + commandName);
         }
+    }
+
+    protected void replaceParameterMarkers(final BsonDocument command) {
     }
 
     @Override

--- a/chameleon-core/src/test/java/org/hibernate/omm/query/NativeQueryTests.java
+++ b/chameleon-core/src/test/java/org/hibernate/omm/query/NativeQueryTests.java
@@ -21,7 +21,6 @@ class NativeQueryTests {
 
     @Test
     void testNativeQueryWithoutParameter() {
-        var id = 1234L;
         var insertedBook = sessionFactory.fromTransaction(session -> {
             var book = new Book();
             book.id = 1234L;
@@ -33,12 +32,11 @@ class NativeQueryTests {
         });
 
         var nativeQuery = "{ aggregate: \"books\", pipeline: [" +
-                "{ $match :  { _id: { $eq: ? } } }, " +
+                "{ $match :  { _id: { $eq: 1234 } } }, " +
                 "{ $project: { _id: 1, publishYear: 1, title: 1, author: 1 } }" +
                 "] }";
         sessionFactory.inTransaction(session -> {
             var query = session.createNativeQuery(nativeQuery, Book.class);
-            query.setParameter(1, id);
             var book = query.getSingleResult();
             assertThat(book).usingRecursiveComparison().isEqualTo(insertedBook);
         });

--- a/chameleon-core/src/test/resources/hibernate.properties
+++ b/chameleon-core/src/test/resources/hibernate.properties
@@ -1,3 +1,4 @@
 hibernate.dialect=org.hibernate.omm.dialect.MongoDialect
 hibernate.connection.provider_class=org.hibernate.omm.jdbc.MongoConnectionProvider
+hibernate.dialect.native_param_markers=true
 hibernate.current_session_context_class=thread


### PR DESCRIPTION
Using '?' for parameter markers is problematic because it creates unparseable JSON, and required the JDBC driver to search for '?' using brittle code that doesn't currently account for the use of '?' in other places, e.g. within a constant string (I'm not sure how JDBC drivers handle this, actually).

The other problem with the current approach is that it requires all parameters to be serialized to a JSON string, only to be subsequently parsed into a BsonValue.

This patch proposes an alternative. Instead of using '?', take advantage of the fact that there is a long-deprecated BSON type called Undefined, whose extended JSON representation is "{$undefined: true}".  By using that String as the custom parameter marker, we can parse the JSON string without any pre-processing, and then recursively replace all instances of BsonUndefined with the BsonValue corresponding to the parameter with the same index.

This approach requires that hibernate.dialect.native_param_markers be set to true (Postgres also does this).

One problem is that it broke the native query test.  I worked around this by removing the parameter from the native query. We will probably have to figure out how to get that working again.

Feel free not to merge this, as I mostly wanted to get the idea across.  Perhaps there is a better way.