### PR TITLE
Support "is null" and "is not null" predicates 

### DIFF
--- a/chameleon-core/src/main/java/org/hibernate/omm/mongoast/AstLiteralValue.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/mongoast/AstLiteralValue.java
@@ -1,0 +1,19 @@
+package org.hibernate.omm.mongoast;
+
+import org.bson.BsonValue;
+import org.bson.BsonWriter;
+import org.bson.codecs.BsonValueCodec;
+import org.bson.codecs.EncoderContext;
+
+public record AstLiteralValue(BsonValue literalValue) implements AstValue {
+    @Override
+    public AstNodeType nodeType() {
+        // TODO: what does Linq3 AST use for literal values?
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void render(final BsonWriter writer) {
+        new BsonValueCodec().encode(writer, literalValue, EncoderContext.builder().build());
+    }
+}

--- a/chameleon-core/src/test/java/org/hibernate/omm/query/NullTests.java
+++ b/chameleon-core/src/test/java/org/hibernate/omm/query/NullTests.java
@@ -1,0 +1,55 @@
+package org.hibernate.omm.query;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.SessionFactory;
+import org.hibernate.omm.extension.MongoIntegrationTest;
+import org.hibernate.omm.extension.SessionFactoryInjected;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Jeff Yemin
+ * @author Nathan Xu
+ * @since 1.0.0
+ */
+@MongoIntegrationTest
+class NullTests {
+
+    @SessionFactoryInjected
+    SessionFactory sessionFactory;
+
+    @Test
+    void test() {
+        var foo = new Foo();
+        foo.id = 1L;
+        foo.possiblyNull = "s";
+
+        var foo2 = new Foo();
+        foo2.id = 2L;
+        foo2.possiblyNull = null;
+
+        sessionFactory.inTransaction(session -> {
+            session.persist(foo);
+            session.persist(foo2);
+        });
+
+        sessionFactory.inSession(session -> {
+            var query = session.createQuery("from Foo where possiblyNull is null", Foo.class);
+            var res = query.getSingleResult();
+            assertThat(res).usingRecursiveComparison().isEqualTo(foo2);
+
+            query = session.createQuery("from Foo where possiblyNull is not null", Foo.class);
+            res = query.getSingleResult();
+            assertThat(res).usingRecursiveComparison().isEqualTo(foo);
+        });
+    }
+
+    @Entity(name = "Foo")
+    static class Foo {
+        @Id
+        Long id;
+        String possiblyNull;
+   }
+}


### PR DESCRIPTION
Change MongoResultSet to properly handle null columns.  The API requires that for columns where the type is a primitive value and the value in the database is null, the "0" value for that type is returned and `wasNull` returns true, e.g. `getBoolean` returns `false`.