### PR TITLE
Use update/deleteOne if filter is _id equality

### DIFF
--- a/chameleon-core/src/main/java/org/hibernate/omm/mongoast/DeleteCommand.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/mongoast/DeleteCommand.java
@@ -18,7 +18,7 @@ public record DeleteCommand(String collection, AstFilter filter) implements AstN
         writer.writeStartDocument();
         writer.writeName("q");
         filter.render(writer);
-        writer.writeInt32("limit", 0);
+        writer.writeInt32("limit", filter.isIdEqualityFilter() ? 1 : 0);
         writer.writeEndDocument();
         writer.writeEndArray();
         writer.writeEndDocument();

--- a/chameleon-core/src/main/java/org/hibernate/omm/mongoast/UpdateCommand.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/mongoast/UpdateCommand.java
@@ -27,7 +27,7 @@ public record UpdateCommand(String collection, AstFilter filter, List<AstFieldUp
         updates.forEach(update ->  update.render(writer));
         writer.writeEndDocument();
         writer.writeEndDocument();
-        writer.writeBoolean("multi", true);
+        writer.writeBoolean("multi", !filter.isIdEqualityFilter());
         writer.writeEndDocument();
         writer.writeEndArray();
         writer.writeEndDocument();

--- a/chameleon-core/src/main/java/org/hibernate/omm/mongoast/filters/AstAndFilter.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/mongoast/filters/AstAndFilter.java
@@ -20,4 +20,9 @@ public record AstAndFilter(List<AstFilter> filters) implements AstFilter {
         writer.writeEndArray();
         writer.writeEndDocument();
     }
+
+    @Override
+    public boolean isIdEqualityFilter() {
+        return filters.stream().anyMatch(AstFilter::isIdEqualityFilter);
+    }
 }

--- a/chameleon-core/src/main/java/org/hibernate/omm/mongoast/filters/AstFieldOperationFilter.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/mongoast/filters/AstFieldOperationFilter.java
@@ -16,4 +16,11 @@ public record AstFieldOperationFilter(AstFilterField field, AstFilterOperation o
         operation.render(writer);
         writer.writeEndDocument();
     }
+
+    @Override
+    public boolean isIdEqualityFilter() {
+        return field().path().equals("_id") &&
+                operation() instanceof AstComparisonFilterOperation comparisonFilterOperation &&
+                comparisonFilterOperation.operator().equals(AstComparisonFilterOperator.EQ);
+    }
 }

--- a/chameleon-core/src/main/java/org/hibernate/omm/mongoast/filters/AstFilter.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/mongoast/filters/AstFilter.java
@@ -3,4 +3,12 @@ package org.hibernate.omm.mongoast.filters;
 import org.hibernate.omm.mongoast.AstNode;
 
 public interface AstFilter extends AstNode {
+    /**
+     * @return true if this is filtering by equality of the _id field.  Useful for determining whether it's safe to do an
+     * updateOne/deleteOne instead of updateMany/deleteMany.  The former is preferred if possible because the server
+     * can automatically retry updateOne/deleteOne but not updateMany/deleteMany.
+     */
+    default boolean isIdEqualityFilter() {
+        return false;
+    }
 }


### PR DESCRIPTION
Not hugely important but wanted to understand if it could be done.

There are a few reasons why update/deleteOne is preferable to use, but the main one is that only update/deleteOne is a candidate for a retryable write outside of a transaction.