### PR TITLE
add an example on how to customize client settings programmatically

### DIFF
--- a/Chameleon-usage-examples/build.gradle
+++ b/Chameleon-usage-examples/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'java'
+}
+
+group = 'org.hibernate.omm'
+version = 'unspecified'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(':chameleon-core')
+    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/Chameleon-usage-examples/src/main/java/org/hibernate/omm/example/ProgrammaticClientSettingsCustomize.java
+++ b/Chameleon-usage-examples/src/main/java/org/hibernate/omm/example/ProgrammaticClientSettingsCustomize.java
@@ -1,0 +1,33 @@
+package org.hibernate.omm.example;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.omm.service.MongoClientSettingsCustomizer;
+
+public class ProgrammaticClientSettingsCustomize {
+
+  public static void main(String[] args) {
+
+    final var cfg = new Configuration();
+    cfg.setProperty(AvailableSettings.JAKARTA_JDBC_URL, "mongodb://127.0.0.1:27017/test");
+
+    // add your entity classes
+
+    final var standardServiceRegistryBuilder = cfg.getStandardServiceRegistryBuilder();
+
+    MongoClientSettingsCustomizer customizer = builder -> {
+      System.out.println("Do whatever you want");
+    };
+
+    standardServiceRegistryBuilder.addService(MongoClientSettingsCustomizer.class, customizer);
+
+    try (var sessionFactory = (SessionFactoryImplementor) cfg.buildSessionFactory()) {
+
+      sessionFactory.inStatelessSession(statelessSession -> {
+        System.out.println("Hello World!");
+      });
+    }
+
+  }
+}

--- a/Chameleon-usage-examples/src/main/resources/hibernate.properties
+++ b/Chameleon-usage-examples/src/main/resources/hibernate.properties
@@ -1,0 +1,5 @@
+hibernate.connection.provider_class=org.hibernate.omm.jdbc.MongoConnectionProvider
+hibernate.dialect_resolvers=org.hibernate.omm.dialect.MongoDialectResolver
+hibernate.dialect.native_param_markers=true
+hibernate.current_session_context_class=thread
+hibernate.type.preferred_uuid_jdbc_type=CHAR

--- a/chameleon-core/build.gradle
+++ b/chameleon-core/build.gradle
@@ -22,13 +22,14 @@ dependencies {
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation libs.mongodb.sync.java.driver, libs.sl4j.api, libs.spotbugs.annotations
+    implementation libs.sl4j.api, libs.spotbugs.annotations
 
     annotationProcessor project(':chameleon-annotation-processor')
     implementation project(':chameleon-annotation-processor')
 
     //implementation project(':hibernate-overlay')
-    implementation libs.hibernate.orm.core
+    api libs.hibernate.orm.core
+    api libs.mongodb.sync.java.driver
 
     // JPA Metamodel Generator (used in JPA Criteria)
     annotationProcessor libs.hibernate.jpamodelgen

--- a/chameleon-core/src/main/java/org/hibernate/omm/service/MongoClientSettingsCustomizer.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/service/MongoClientSettingsCustomizer.java
@@ -1,0 +1,8 @@
+package org.hibernate.omm.service;
+
+import org.hibernate.service.Service;
+import com.mongodb.MongoClientSettings;
+
+public interface MongoClientSettingsCustomizer extends Service {
+  void contribute(MongoClientSettings.Builder builder);
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,4 +16,5 @@ include ':chameleon-core'
 include ':chameleon-testing'
 include ':chameleon-annotation-processor'
 include ':hibernate-overlay'
+include 'Chameleon-usage-examples'
 


### PR DESCRIPTION
show case the most flexible and powerful way to go about MongoClientSettings by using ServiceRegistry to inject customizer service.