### PR TITLE
Read write concerns

### DIFF
--- a/chameleon-core/src/main/java/org/hibernate/omm/boot/MongoSessionFactoryBuilderFactory.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/boot/MongoSessionFactoryBuilderFactory.java
@@ -1,0 +1,15 @@
+package org.hibernate.omm.boot;
+
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.boot.spi.SessionFactoryBuilderFactory;
+import org.hibernate.boot.spi.SessionFactoryBuilderImplementor;
+
+public class MongoSessionFactoryBuilderFactory implements SessionFactoryBuilderFactory {
+
+  @Override
+  public SessionFactoryBuilder getSessionFactoryBuilder(MetadataImplementor metadata, SessionFactoryBuilderImplementor defaultBuilder) {
+    return new MongoSessionFactoryBuilderImpl(defaultBuilder);
+  }
+
+}

--- a/chameleon-core/src/main/java/org/hibernate/omm/boot/MongoSessionFactoryBuilderImpl.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/boot/MongoSessionFactoryBuilderImpl.java
@@ -1,6 +1,5 @@
 package org.hibernate.omm.boot;
 
-import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.spi.AbstractDelegatingSessionFactoryBuilderImplementor;
 import org.hibernate.boot.spi.SessionFactoryBuilderImplementor;
 import org.hibernate.engine.spi.SessionFactoryImplementor;

--- a/chameleon-core/src/main/java/org/hibernate/omm/boot/MongoSessionFactoryBuilderImpl.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/boot/MongoSessionFactoryBuilderImpl.java
@@ -1,0 +1,31 @@
+package org.hibernate.omm.boot;
+
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.spi.AbstractDelegatingSessionFactoryBuilderImplementor;
+import org.hibernate.boot.spi.SessionFactoryBuilderImplementor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.omm.jdbc.MongoConnectionProvider;
+import org.hibernate.omm.service.MongoSessionFactory;
+
+public class MongoSessionFactoryBuilderImpl extends AbstractDelegatingSessionFactoryBuilderImplementor<SessionFactoryBuilderImplementor>
+    implements SessionFactoryBuilderImplementor {
+
+  public MongoSessionFactoryBuilderImpl(SessionFactoryBuilderImplementor delegate) {
+    super( delegate );
+  }
+
+  @Override
+  protected SessionFactoryBuilderImplementor getThis() {
+    return this;
+  }
+
+  @Override
+  public MongoSessionFactory build() {
+    SessionFactoryImplementor delegate = (SessionFactoryImplementor) super.build();
+    MongoConnectionProvider mongoConnectionProvider = delegate.getServiceRegistry().getService(MongoConnectionProvider.class);
+    MongoSessionFactory mongoSessionFactory = new MongoSessionFactory(delegate);
+    mongoConnectionProvider.setSessionFactory(mongoSessionFactory);
+    return mongoSessionFactory;
+  }
+}
+

--- a/chameleon-core/src/main/java/org/hibernate/omm/jdbc/MongoConnection.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/jdbc/MongoConnection.java
@@ -15,6 +15,7 @@ import org.hibernate.omm.jdbc.adapter.ConnectionAdapter;
 import org.hibernate.omm.jdbc.exception.CommandRunFailSQLException;
 import org.hibernate.omm.jdbc.exception.SimulatedSQLException;
 import org.hibernate.omm.service.CommandRecorder;
+import org.hibernate.omm.service.MongoSession;
 import org.hibernate.omm.type.array.MongoArray;
 
 /**
@@ -85,7 +86,7 @@ public class MongoConnection implements ConnectionAdapter {
     @Override
     public void setAutoCommit(final boolean autoCommit) {
         if (!autoCommit) {
-            this.clientSession.startTransaction();
+          this.clientSession.startTransaction(MongoSession.transactionOptionsThreadLocal.get());
         }
         this.autoCommit = autoCommit;
     }

--- a/chameleon-core/src/main/java/org/hibernate/omm/jdbc/MongoConnectionProvider.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/jdbc/MongoConnectionProvider.java
@@ -19,6 +19,7 @@ import org.bson.codecs.configuration.CodecRegistry;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.omm.service.CommandRecorder;
 import org.hibernate.service.UnknownUnwrapTypeException;
 import org.hibernate.service.spi.Configurable;
@@ -39,6 +40,8 @@ public class MongoConnectionProvider
 
     public @MonotonicNonNull MongoDatabase mongoDatabase;
     private @MonotonicNonNull MongoClient mongoClient;
+
+    private @MonotonicNonNull SessionFactoryImplementor sessionFactory;
 
     @Override
     public void configure(final Map<String, Object> configurationValues) {
@@ -83,7 +86,7 @@ public class MongoConnectionProvider
         }
         ClientSession clientSession = mongoClient.startSession();
         CommandRecorder commandRecorder = serviceRegistry.getService(CommandRecorder.class);
-        return new MongoConnection(mongoDatabase, clientSession, commandRecorder);
+        return new MongoConnection(sessionFactory, mongoDatabase, clientSession, commandRecorder);
     }
 
     @Override
@@ -124,5 +127,9 @@ public class MongoConnectionProvider
         } else {
             return connectionString.substring(startIndex, endIndex);
         }
+    }
+
+    public void setSessionFactory(SessionFactoryImplementor sessionFactory) {
+      this.sessionFactory = sessionFactory;
     }
 }

--- a/chameleon-core/src/main/java/org/hibernate/omm/service/MongoSession.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/service/MongoSession.java
@@ -1,0 +1,41 @@
+package org.hibernate.omm.service;
+
+import com.mongodb.ReadConcern;
+import com.mongodb.TransactionOptions;
+import com.mongodb.WriteConcern;
+import org.hibernate.Transaction;
+import org.hibernate.engine.spi.SessionDelegatorBaseImpl;
+import org.hibernate.engine.spi.SessionImplementor;
+
+public class MongoSession extends SessionDelegatorBaseImpl implements SessionImplementor {
+
+    public static ThreadLocal<TransactionOptions> transactionOptionsThreadLocal = new ThreadLocal<>();
+
+    private ReadConcern defaultTransactionReadConcern;
+    private WriteConcern defaultTransactionWriteConcern;
+
+    public MongoSession(SessionImplementor delegate) {
+        super(delegate);
+    }
+
+    public void setDefaultTransactionReadConcern(ReadConcern defaultTransactionReadConcern) {
+        this.defaultTransactionReadConcern = defaultTransactionReadConcern;
+    }
+
+    public void setDefaultTransactionWriteConcern(WriteConcern defaultTransactionWriteConcern) {
+        this.defaultTransactionWriteConcern = defaultTransactionWriteConcern;
+    }
+
+    public Transaction beginTransaction() {
+        return beginTransaction(defaultTransactionReadConcern, defaultTransactionWriteConcern);
+    }
+
+    public Transaction beginTransaction(ReadConcern transactionReadConcern, WriteConcern transactionWriteConcern) {
+      var transactionOptions = TransactionOptions.builder()
+          .readConcern(transactionReadConcern)
+          .writeConcern(transactionWriteConcern)
+          .build();
+      transactionOptionsThreadLocal.set(transactionOptions);
+        return super.beginTransaction();
+    }
+}

--- a/chameleon-core/src/main/java/org/hibernate/omm/service/MongoSessionFactory.java
+++ b/chameleon-core/src/main/java/org/hibernate/omm/service/MongoSessionFactory.java
@@ -1,0 +1,58 @@
+package org.hibernate.omm.service;
+
+import static org.hibernate.internal.TransactionManagement.manageTransaction;
+
+import com.mongodb.ReadConcern;
+import com.mongodb.WriteConcern;
+import java.util.function.Consumer;
+import org.hibernate.Session;
+import org.hibernate.engine.spi.SessionFactoryDelegatingImpl;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+
+public class MongoSessionFactory extends SessionFactoryDelegatingImpl implements SessionFactoryImplementor {
+
+  private SessionFactoryImplementor delegate;
+
+  private ReadConcern defaultSessionReadConcern;
+  private WriteConcern defaultSessionWriteConcern;
+
+  public MongoSessionFactory(SessionFactoryImplementor delegate) {
+    super(delegate);
+  }
+
+  public void setDefaultSessionReadConcern(ReadConcern defaultSessionReadConcern) {
+    this.defaultSessionReadConcern = defaultSessionReadConcern;
+  }
+
+  public void setDefaultSessionWriteConcern(WriteConcern defaultSessionWriteConcern) {
+    this.defaultSessionWriteConcern = defaultSessionWriteConcern;
+  }
+
+  @Override
+  public MongoSession openSession() {
+    return openSession(defaultSessionReadConcern, defaultSessionWriteConcern);
+  }
+
+  public MongoSession openSession(ReadConcern readConcern, WriteConcern writeConcern) {
+    MongoSession mongoSession = new MongoSession(delegate.openSession());
+    mongoSession.setDefaultTransactionReadConcern(defaultSessionReadConcern);
+    mongoSession.setDefaultTransactionWriteConcern(defaultSessionWriteConcern);
+    if (readConcern != null) {
+      mongoSession.setDefaultTransactionReadConcern(readConcern);
+    }
+    if (writeConcern != null) {
+      mongoSession.setDefaultTransactionWriteConcern(writeConcern);
+    }
+    return mongoSession;
+  }
+
+  @Override
+  public void inTransaction(Consumer<Session> action) {
+    inTransaction(action, defaultSessionReadConcern, defaultSessionWriteConcern);
+  }
+
+  public void inTransaction(Consumer<Session> action, ReadConcern readConcern, WriteConcern writeConcern) {
+    inSession( session -> manageTransaction( session, ((MongoSession) session).beginTransaction(readConcern, writeConcern), action ) );
+  }
+
+}

--- a/chameleon-core/src/main/resources/META-INF/services/org.hibernate.boot.spi.SessionFactoryBuilderFactory
+++ b/chameleon-core/src/main/resources/META-INF/services/org.hibernate.boot.spi.SessionFactoryBuilderFactory
@@ -1,0 +1,1 @@
+org.hibernate.omm.boot.MongoSessionFactoryBuilderService

--- a/chameleon-core/src/main/resources/META-INF/services/org.hibernate.boot.spi.SessionFactoryBuilderFactory
+++ b/chameleon-core/src/main/resources/META-INF/services/org.hibernate.boot.spi.SessionFactoryBuilderFactory
@@ -1,1 +1,1 @@
-org.hibernate.omm.boot.MongoSessionFactoryBuilderService
+org.hibernate.omm.boot.MongoSessionFactoryBuilderFactory

--- a/chameleon-core/src/test/java/org/hibernate/omm/ReadWriteConcernTests.java
+++ b/chameleon-core/src/test/java/org/hibernate/omm/ReadWriteConcernTests.java
@@ -1,0 +1,60 @@
+package org.hibernate.omm;
+
+import com.mongodb.ReadConcern;
+import com.mongodb.TransactionOptions;
+import com.mongodb.WriteConcern;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.SessionFactory;
+import org.hibernate.omm.extension.MongoIntegrationTest;
+import org.hibernate.omm.extension.SessionFactoryInjected;
+import org.hibernate.omm.service.MongoSessionFactory;
+import org.junit.jupiter.api.Test;
+
+@MongoIntegrationTest
+class ReadWriteConcernTests {
+
+  @SessionFactoryInjected
+  SessionFactory sessionFactory;
+
+  @Test
+  void test_client_level_concerns() {
+    MongoSessionFactory mongoSessionFactory = (MongoSessionFactory) sessionFactory;
+    mongoSessionFactory.setReadConcern(ReadConcern.MAJORITY);
+    mongoSessionFactory.setWriteConcern(WriteConcern.ACKNOWLEDGED);
+
+    mongoSessionFactory.inTransaction(session -> {
+      System.out.println("Hello World");
+    });
+  }
+
+  @Test
+  void test_client_session_level_concerns() {
+    MongoSessionFactory mongoSessionFactory = (MongoSessionFactory) sessionFactory;
+
+    mongoSessionFactory.inSession(ReadConcern.MAJORITY, WriteConcern.ACKNOWLEDGED, session -> {
+      System.out.println("Hello World");
+    });
+  }
+
+  @Test
+  void test_transaction_level_concerns() {
+    MongoSessionFactory mongoSessionFactory = (MongoSessionFactory) sessionFactory;
+
+    TransactionOptions transactionOptions = TransactionOptions.builder()
+            .readConcern(ReadConcern.MAJORITY)
+            .writeConcern(WriteConcern.ACKNOWLEDGED)
+            .build();
+    mongoSessionFactory.inTransaction(transactionOptions, session -> {
+        System.out.println("Hello World");
+    });
+  }
+
+  @Entity(name = "Book")
+  static class Book {
+    @Id
+    int id;
+    String title;
+  }
+
+}

--- a/chameleon-core/src/test/resources/hibernate.properties
+++ b/chameleon-core/src/test/resources/hibernate.properties
@@ -17,7 +17,8 @@
 #
 #jakarta.persistence.jdbc.url=mongodb://localhost/chameleon-test
 hibernate.connection.provider_class=org.hibernate.omm.jdbc.MongoConnectionProvider
-hibernate.dialect_resolvers=org.hibernate.omm.dialect.MongoDialectResolver
+#hibernate.dialect_resolvers=org.hibernate.omm.dialect.MongoDialectResolver
+hibernate.dialect=org.hibernate.omm.dialect.MongoDialect
 hibernate.dialect.native_param_markers=true
 hibernate.current_session_context_class=thread
 hibernate.type.preferred_uuid_jdbc_type=CHAR


### PR DESCRIPTION
A POC PR to showcase a straightforward idea to implement MongoDB's read/write concern.

Firstly we need to create our own customized SessionFactory and Session, named `MongoSessionFactory` and `MongoSession` respectively. It is not hard to utilize Hibernate's existing bootstrap mechnaism to inject them, by using Hibernate's existing delegating abstract classes. The injecting classes are in the `boot` package, and the two `MongoSessionFactory` and `MongoSession` are in the `service` package (not accurate, maybe moving both to `engine` new package is more appropriate).

Both `MongoSessionFactory` and `MongoSession` allow for their own read/write concerns setting and the former values are the default for the latter. The last level is transaction level and that is the challenge for JDBC transaction flow doesn't allow for passing ad-hoc concern parameter, but we have a way out. Hibernate's Session is thread-safe, so everything is run sequentially in a session, including sequential transaction usage. So whenever we need to pass a concern to a transaction, we use Java's `ThreadLocal` mechanism to pass the concern.

Transaction concern is set in `MongoSession`s static `ThreadLocal` variable and in `MongoConnection` where a JDBC transaction is to be created, it will fetch the concern from `MongoSession`'s `ThreadLocal` static variable. That should be enough, from my understanding.

A simple testing case was created to showcase the three-level read/write concern customization. Industrial testing definitively needs command monitor to verify and it is weak in this POC project for the commandRecorder mechanism is weak. But you can set a breakpoint in debugger in `MongoConnection#setAutoCommit()` to verify the concerns are used as expected.
